### PR TITLE
typo in var definition removedItems

### DIFF
--- a/src/web/kendo.backbone.collection.js
+++ b/src/web/kendo.backbone.collection.js
@@ -16,7 +16,7 @@
       },
 
       splice: function(index, howMany) {
-        var itemsToInsert, removedItemx, idx, length;
+        var itemsToInsert, removedItems, idx, length;
 
         itemsToInsert = Array.prototype.slice.call(arguments, 2);
 


### PR DESCRIPTION
just a typo in a var declaration.
