### PR TITLE
Prevent observable from converting this.backbone

### DIFF
--- a/demos/public/popup.html
+++ b/demos/public/popup.html
@@ -46,9 +46,9 @@
                 $("#log").text(kendo.stringify(products.toJSON()));
 
                 $("#grid").kendoGrid({
-                    editable: true,
+                    editable: "popup",
                     toolbar: ["create"],
-                    columns: ["ProductID", "Name", { command: "destroy" }],
+                    columns: ["ProductID", "Name", { command: ["edit", "destroy"] }],
                     dataSource: {
                         schema: {
                             model: ProductWrapper

--- a/src/web/kendo.backbone.collection.js
+++ b/src/web/kendo.backbone.collection.js
@@ -12,7 +12,7 @@
       init: function(collection) {
         ObservableArray.fn.init.call(this, collection.models, model);
 
-        this.collection = collection;
+        this._collection = collection;
       },
 
       splice: function(index, howMany) {
@@ -24,13 +24,13 @@
 
         if (removedItems.length) {
           for (idx = 0, length = removedItems.length; idx < length; idx++) {
-            this.collection.remove(removedItems[idx].backbone);
+            this._collection.remove(removedItems[idx].backbone);
           }
         }
 
         if (itemsToInsert.length) {
           for (idx = 0, length = itemsToInsert.length; idx < length; idx++) {
-            this.collection.unshift(itemsToInsert[idx].backbone);
+            this._collection.unshift(itemsToInsert[idx].backbone);
           }
         }
 

--- a/src/web/kendo.backbone.model.js
+++ b/src/web/kendo.backbone.model.js
@@ -13,13 +13,14 @@
           model = new BackboneModel(model);
         }
 
+        this.idField = model.idAttribute;
         Model.fn.init.call(this, model.toJSON());
-        this.backbone = model;
+        this._backbone = model;
       },
       set: function(field, value) {
         Model.fn.set.call(this, field, value);
 
-        this.backbone.set(field, value);
+        this._backbone.set(field, value);
       }
     });
   }


### PR DESCRIPTION
Using this._backbone will instruct ObservableObject to skip attempting
to turn the _backbone obj into an observable. Required as collection &
model have a circular reference that causes a stack overflow in newer 
kendo versions
